### PR TITLE
Fix WebNFC usage on modern Chrome

### DIFF
--- a/src/components/GameScanner.vue
+++ b/src/components/GameScanner.vue
@@ -218,8 +218,8 @@ export default {
       this.tag = message
       this.start()
     },
-    show() {
-      startWatch(this.handleTag)
+    async show() {
+      await startWatch(this.handleTag);
     },
     hide() {
       cancelWatch()

--- a/src/components/MedicalDiagnosis.vue
+++ b/src/components/MedicalDiagnosis.vue
@@ -71,8 +71,8 @@ export default {
         this.resultText = get(this.res, 'data.description', this.tagNotFoundMessage) + '\n\nReady to scan another injury';
         this.state = 'results';
     },
-    show() {
-      startWatch(this.getRecords)
+    async show() {
+      await startWatch(this.getRecords);
     },
     hide() {
       cancelWatch()

--- a/src/components/MedicalRecords.vue
+++ b/src/components/MedicalRecords.vue
@@ -119,8 +119,8 @@ Scan a patient ID card`;
         this.dataProgress2++
       }, 3 * analyseBaseTime * skillFactor)
     },
-    show() {
-      startWatch(this.getRecords)
+    async show() {
+      await startWatch(this.getRecords);
     },
     hide() {
       cancelWatch()

--- a/src/components/MedicalSample.vue
+++ b/src/components/MedicalSample.vue
@@ -150,8 +150,8 @@ export default {
       this.isCatalogIdOk = false;
       this.validateForm();
     },
-    show() {
-      startWatch(this.setBioId)
+    async show() {
+      await startWatch(this.setBioId);
     },
     hide() {
         cancelWatch()

--- a/src/components/MedicalScanner.vue
+++ b/src/components/MedicalScanner.vue
@@ -196,8 +196,8 @@ export default {
             this.$ons.notification.toast(`Scanned tag is not ${wantedIdType}`, { timeout: 2500, animation: 'fall' });
         }
     },
-    show() {
-        startWatch(this.setBioId)
+    async show() {
+        await startWatch(this.setBioId);
     },
     hide() {
         cancelWatch()

--- a/src/components/ScienceArtifactDetails.vue
+++ b/src/components/ScienceArtifactDetails.vue
@@ -68,8 +68,8 @@ ${ parseEntries(this.record.entries) }
 Ready to scan a new artifact.`
     this.state = 'results';
     },
-    show() {
-    startWatch(this.getRecords)
+    async show() {
+      await startWatch(this.getRecords);
     },
     hide() {
       cancelWatch()
@@ -123,8 +123,8 @@ Ready to scan an artifact.`
   created() {
     this.debouncedGetRecords = debounce(this.getRecords, 1000);
   },
-  show() {
-    startWatch(this.getRecords)
+  async show() {
+    await startWatch(this.getRecords);
   },
   hide() {
     cancelWatch()

--- a/src/components/ScienceInspectObject.vue
+++ b/src/components/ScienceInspectObject.vue
@@ -72,8 +72,8 @@ export default {
       this.resultText = get(this.res, 'data.description', this.tagNotFoundMessage) + '\n\nReady to scan another object';
       this.state = 'results';
     },
-    show() {
-      startWatch(this.getRecords)
+    async show() {
+      await startWatch(this.getRecords);
     },
     hide() {
       cancelWatch()

--- a/src/nfc.js
+++ b/src/nfc.js
@@ -1,32 +1,66 @@
+let currentHandler = undefined;
+let watchAdded = false;
 
-let currentHandler = undefined
-let watchAdded = false
+async function initializeNfcReader() {
+  // eslint-disable-next-line no-undef
+  const ndef = new NDEFReader();
+  await ndef.scan();
+  console.log("NFC Reader initialized!");
 
-export function startWatch(handler) {
-  if (!watchAdded) {
-    if ('nfc' in navigator) {
-      navigator.nfc.watch(nfcHandler, {mode: 'any'})
-    }
-    watchAdded = true
-  }
-  currentHandler = handler;
+  ndef.addEventListener("readingerror", () => {
+    console.log("NFC Tag could not be read");
+  });
+
+  ndef.addEventListener("reading", nfcHandler);
+  watchAdded = true;
 }
+
+export async function startWatch(handler) {
+  try {
+    if (!watchAdded && hasNfc()) {
+      await initializeNfcReader();
+    }
+    currentHandler = handler;
+  } catch (error) {
+    console.log("NFC Error: " + error);
+  }
+}
+
 export function cancelWatch() {
-  currentHandler = undefined
+  currentHandler = undefined;
 }
 
 export function hasNfc() {
-  return 'nfc' in navigator;
+  return "NDEFReader" in window;
 }
 
-function nfcHandler(message) {
-  const record = message.records.find(record => record.recordType === 'text')
-  if (record && currentHandler) {
-    currentHandler(record.data)
+function nfcHandler({ message, serialNumber }) {
+  if (message.records.length !== 1) {
+    console.log("Unexpected number of records in NFC message, ignoring");
+    return;
   }
+
+  const record = message.records[0];
+  if (record.recordType !== "text") {
+    console.log("Unexpected record type in NFC message, ignoring");
+    return;
+  }
+
+  const textDecoder = new TextDecoder(record.encoding);
+  const content = textDecoder.decode(record.data);
+  console.log(`NFC Tag content: '${content}'`);
+
+  if (content && currentHandler) {
+    currentHandler(content);
+  }
+}
+
+export async function isNfcPermissionGranted() {
+  const nfcPermissionStatus = await navigator.permissions.query({ name: "nfc" });
+  return nfcPermissionStatus.state === "granted";
 }
 
 // Allow debugging from console
 window.nfcDebugMessage = function (msg) {
   currentHandler(msg);
-}
+};

--- a/vue.config.js
+++ b/vue.config.js
@@ -2,4 +2,8 @@ const { defineConfig } = require('@vue/cli-service')
 module.exports = defineConfig({
   transpileDependencies: true,
   publicPath: process.env.NODE_ENV === 'production' ? '/hansca/' : '/',
+  devServer: {
+    // HTTPS is required for WebNFC to work when testing on a real device
+    // https: true,
+  }
 })


### PR DESCRIPTION
Shows a "Enable NFC reader" button in the Greeter view if NFC permission has not yet been granted. Clicking it will prompt the user for the permission. The permission only needs to be granted once.

Also adds a "Fullscreen" button to Greeter view, to hide the address bar.